### PR TITLE
#travial support to RxSwift 6.x  (from 6.2 to 6.5 and latest)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "7c17a6ccca06b5c107cfa4284e634562ddaf5951",
-          "version": "6.2.0"
+          "revision": "b4307ba0b6425c0ba4178e138799946c3da594f8",
+          "version": "6.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "RxLocalizer", targets: ["RxLocalizer"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.2.0"))
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0"))
     ],
     targets: [
          .target(

--- a/RxLocalizer.podspec
+++ b/RxLocalizer.podspec
@@ -10,8 +10,8 @@ s.license = { :type => "MIT", :file => "LICENSE" }
 s.author = { "Vladislav Khambir" => "vlad.khambir@gmail.com" }
 s.homepage = "https://github.com/RxSwiftCommunity/RxLocalizer"
 s.source = { :git => "https://github.com/RxSwiftCommunity/RxLocalizer.git", :tag => "#{s.version}" }
-s.dependency 'RxSwift', '~> 6.2.0'
-s.dependency 'RxCocoa', '~> 6.2.0'
+s.dependency 'RxSwift', '~> 6.0'
+s.dependency 'RxCocoa', '~> 6.0'
 s.source_files = 'Source/*.swift'
 s.swift_version = "5.3.3"
 


### PR DESCRIPTION
- [x] update RxSwift to 6.5 and latest [Swift Package Manager & CocoaPods]